### PR TITLE
pointless assertions so that bacon does not complaing

### DIFF
--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -91,6 +91,7 @@ describe "A method stub" do
   end
 
   it "should ignore when the stubbed method is never called" do
+    true.should == true
   end
 end
 
@@ -102,10 +103,11 @@ describe "A method stub with arguments" do
   end
 
   it "should ignore when never called" do
+    true.should == true
   end
 
   it "should ignore when called with expected argument" do
-    @object.stubbed_method(:expected_arg)
+    @object.stubbed_method(:expected_arg).should == :stubbed_value
   end
 
   it "should raise a NoMethodError when called with no arguments" do


### PR DESCRIPTION
Hi @Sergey 

Thank you very much for this gem. I was having troubles since the rubymotion community didn't have mocks. 

This pull request is just to solve the messages like: 

``` bash
Bacon::Error: empty specification: A method stub should ignore when the stubbed method is never called
    spec.rb:383:in `block in finish_spec': A method stub - should ignore when the stubbed method is never called
    spec.rb:403:in `execute_block'
    spec.rb:383:in `finish_spec'
    spec.rb:281:in `run_spec_block'
    spec.rb:294:in `run'

Bacon::Error: empty specification: A method stub with arguments should ignore when never called
    spec.rb:383:in `block in finish_spec': A method stub with arguments - should ignore when never called
    spec.rb:403:in `execute_block'
    spec.rb:383:in `finish_spec'
    spec.rb:281:in `run_spec_block'
    spec.rb:294:in `run'

Bacon::Error: empty specification: A method stub with arguments should ignore when called with expected argument
    spec.rb:383:in `block in finish_spec': A method stub with arguments - should ignore when called with expected argument
    spec.rb:403:in `execute_block'
    spec.rb:383:in `finish_spec'
    spec.rb:281:in `run_spec_block'
    spec.rb:294:in `run'

```
