### PR TITLE
At least implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ You can now write [Bacon](https://github.com/chneukirchen/bacon) specs like this
 
       Person.first
     end
+
+    it "knows how many times we call a method" do
+      Person.should.receive(:find).at_least(3)
+      
+      Person.list
+    end
   end
 ```
 
@@ -59,6 +65,7 @@ Contributors
 * [James Tucker](https://github.com/raggi) for #times, #once, #never expectation matchers.
 * [Peter Kim](https://github.com/petejkim) for [MacBacon](https://github.com/alloy/MacBacon) support.
 * [Yossef Mendelssohn](https://github.com/ymendel) for Ruby 1.9.2 compatibility fixes.
+* [Ivan Acosta-Rubio](https://github.com/ivanacostarubio) for at_least expectation matcher.
 
 Thanks to
 ---------

--- a/lib/motion-facon/expectation.rb
+++ b/lib/motion-facon/expectation.rb
@@ -83,12 +83,19 @@ module Facon
     end
 
     # Returns true if this expectation has been met.
-    # TODO at_least and at_most conditions
+    # TODO at_most conditions
     def met?
-      return true if @expected_received_count == :any ||
-        @expected_received_count == @actual_received_count
+      return true if meets_at_least_requirements? ||
+      (@expected_received_count == :any) ||
+      (@expected_received_count == @actual_received_count)
 
       raise_expectation_error(self)
+    end
+
+    def at_least(val)
+      @at_least = true
+      @expected_received_count = val
+      self
     end
 
     # Returns true if the given <code>method</code> and arguments match this
@@ -117,6 +124,11 @@ module Facon
     def never; times(0); end
 
     private
+
+      def meets_at_least_requirements?
+        @at_least and @actual_received_count >= @expected_received_count 
+      end
+
       def check_arguments(args)
         case @argument_expectation
         when :any then true

--- a/spec/expectation_spec.rb
+++ b/spec/expectation_spec.rb
@@ -180,4 +180,32 @@ describe "A mock object" do
 
     lambda { @mock.spec_verify }.should.raise(Facon::MockExpectationError).message.should == "Mock 'test mock' expected :message with (any args) 0 times, but received it 1 time"
   end
+
+  describe "at_least" do
+    it "fails if method is never called" do
+      @mock.should.receive(:message).at_least(4)
+      lambda{
+        @mock.spec_verify
+      }.should.raise(Facon::MockExpectationError).message.should == "Mock 'test mock' expected :message with (any args) 4 times, but received it 0 times"
+    end
+
+    it "fails if the method gets call less times that expected" do
+      @mock.should.receive(:message).at_least(4)
+      3.times { @mock.message }
+      lambda{ @mock.spec_verify }.should.raise(Facon::MockExpectationError)
+    end
+
+    it "passed when the method is call" do
+      @mock.should.receive(:message).at_least(4)
+      4.times { @mock.message }
+      lambda{ @mock.spec_verify}.should.not.raise
+    end
+
+    it "is ok if we call the method more times that required" do
+      @mock.should_receive(:message).at_least(4)
+      5.times{ @mock.message}
+      lambda{ @mock.spec_verify }.should.not.raise
+    end
+  end
+
 end

--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -91,6 +91,7 @@ describe "A method stub" do
   end
 
   it "should ignore when the stubbed method is never called" do
+    true.should == true
   end
 end
 
@@ -102,10 +103,11 @@ describe "A method stub with arguments" do
   end
 
   it "should ignore when never called" do
+    true.should == true
   end
 
   it "should ignore when called with expected argument" do
-    @object.stubbed_method(:expected_arg)
+    @object.stubbed_method(:expected_arg).should == :stubbed_value
   end
 
   it "should raise a NoMethodError when called with no arguments" do


### PR DESCRIPTION
Hey Sergey! 

Ivan here again! :P 

This pull request implements the at_least(number) expectation. I would love to know how do you feel about: 

``` ruby
@mock.should_receive(:message).at_least(4)
```

vs 

``` ruby
@mock.should_receive(:message).at_least(4).times
```
