### PR TITLE
Only include facon modules once..

### DIFF
--- a/lib/motion-facon/proxy.rb
+++ b/lib/motion-facon/proxy.rb
@@ -100,7 +100,11 @@ module Facon
           metaclass.instance_eval do
             if method_defined?(munged_method.to_s)
               alias_method method, munged_method
-              undef_method munged_method
+              begin
+                undef_method munged_method
+              rescue => e
+                NSLog "\n >> Facon Error: #{e.message}"
+              end
             else
               undef_method method
             end

--- a/lib/motion-facon/spec_helpers.rb
+++ b/lib/motion-facon/spec_helpers.rb
@@ -1,6 +1,7 @@
 module Facon
   module SpecHelpers
     def self.extended(base)
+      return if Object.included_modules.include?(Facon::Mockable)
       Object.class_eval { include Facon::Mockable }
       base.class.class_eval { include Facon::Baconize::ContextExtensions }
       Should.class_eval { include Facon::Baconize::ShouldExtensions }

--- a/spec/spec_helpers_spec.rb
+++ b/spec/spec_helpers_spec.rb
@@ -1,0 +1,20 @@
+describe "Facon::SpecHelpers" do
+
+  extend Facon::SpecHelpers
+
+  it "includes Facon::Mockable in Object" do
+    Object.included_modules.should.include Facon::Mockable
+  end
+
+  # to verify this test, uncomment line #4 in lib/motion-facon/spec_helpers.rb
+  describe "It doesn't error when extending the spec helpers again" do
+
+    extend Facon::SpecHelpers
+
+    it "includes Facon::Mockable in Object" do
+      Object.included_modules.should.include Facon::Mockable
+    end
+
+  end
+
+end


### PR DESCRIPTION
When calling `extend Facon::SpecHelpers` multiple times in one test (or one app) I was getting the following error:

```
Terminating app due to uncaught exception 'NameError', reason: 'spec_helpers.rb:7:in `extended:': undefined method `mock:' for class `Should' (NameError)
```

`Facon::Baconize::ShouldExtensions` was causing the issue when trying to undefine methods that were already undefined.

To reproduce this error, uncomment line #4 in `lib/motion-facon/spec_helpers.rb` and run `rake spec`

Cheers! :beers:
